### PR TITLE
updated for Debian 12 plus Mongo 4.4 for Unifi 7.5.x support

### DIFF
--- a/Basic_UniFi_Install.sh
+++ b/Basic_UniFi_Install.sh
@@ -1,7 +1,7 @@
 # Based on UI documentation https://help.ui.com/hc/en-us/articles/220066768-UniFi-How-to-Install-and-Update-via-APT-on-Debian-or-Ubuntu
 
 # Install base needs and java 11
-echo "deb http://deb.debian.org/debian/ bullseye main" | sudo tee /etc/apt/sources.list.d/bullseye.list # Needed for Debian 12, openjdk-11-jre-headless no longer in distro
+echo "deb http://deb.debian.org/debian/ bullseye main" | sudo tee /etc/apt/sources.list.d/bullseye.list # Needed for Debian 12 openjdk-11-jre-headless no longer in distro
 sudo apt-get update && sudo apt-get install ca-certificates apt-transport-https openjdk-11-jre-headless gnupg
 
 # Add Ubiquiti & Mongo to the sources
@@ -14,6 +14,10 @@ sudo wget -O /etc/apt/trusted.gpg.d/unifi-repo.gpg https://dl.ui.com/unifi/unifi
 
 # Hold the java version for compatability so it does not break with updates
 sudo apt-mark hold openjdk-11-*
+
+# To get rid of the depricated apt key message on future apt updates: 
+# run sudo apt-key list and take the last 8 digits of the mongodb key shown here as 90CFB1F5
+sudo apt-key export 90CFB1F5 | sudo gpg --dearmour -o /etc/apt/trusted.gpg.d/mongodb.gpg
 
 # Install the UniFi controller
 sudo apt-get update && sudo apt-get install unifi -y

--- a/Basic_UniFi_Install.sh
+++ b/Basic_UniFi_Install.sh
@@ -1,14 +1,15 @@
 # Based on UI documentation https://help.ui.com/hc/en-us/articles/220066768-UniFi-How-to-Install-and-Update-via-APT-on-Debian-or-Ubuntu
 
 # Install base needs and java 11
-sudo apt-get update && sudo apt-get install ca-certificates apt-transport-https openjdk-11-jre-headless
+echo "deb http://deb.debian.org/debian/ bullseye main" | sudo tee /etc/apt/sources.list.d/bullseye.list # Needed for Debian 12, openjdk-11-jre-headless no longer in distro
+sudo apt-get update && sudo apt-get install ca-certificates apt-transport-https openjdk-11-jre-headless gnupg
 
 # Add Ubiquiti & Mongo to the sources
 echo 'deb https://www.ui.com/downloads/unifi/debian stable ubiquiti' | sudo tee /etc/apt/sources.list.d/100-ubnt-unifi.list
-echo "deb https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+echo "deb https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
 
 # Add trust for Ubiquiti and Mongo sources
-wget -qO - https://www.mongodb.org/static/pgp/server-3.4.asc | sudo apt-key add -
+wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
 sudo wget -O /etc/apt/trusted.gpg.d/unifi-repo.gpg https://dl.ui.com/unifi/unifi-repo.gpg
 
 # Hold the java version for compatability so it does not break with updates


### PR DESCRIPTION
Thanks for your helpful little script,  I thought I'd throw in an update for others to share as the original script is now broken..

a few separate commits here, one updates to Debian 12 flavours and a more recent version of Mongo to support newest Unifi controller builds past 7.5, the second is just a quick way to get rid of the annoying apt key depricated messages on subsequent updates.



All the best!

